### PR TITLE
Fix issue #51: Use AudioContext instead of webkitAudioContext when possible

### DIFF
--- a/samples/audio/box2d-js/box2d-audio.html
+++ b/samples/audio/box2d-js/box2d-audio.html
@@ -24,8 +24,7 @@
     var gCount = 0;
     
     // Temporary patch until all browsers support unprefixed context.
-    if (window.hasOwnProperty('AudioContext') && !window.hasOwnProperty('webkitAudioContext'))
-        window.webkitAudioContext = AudioContext;
+    AudioContext = AudioContext || webkitAudioContext;
 
     // Callback when a collision occurs
     function countContact(body1, body2) {
@@ -180,7 +179,7 @@
     function init() {
       prettyPrint();
 
-      context = new webkitAudioContext();
+      context = new AudioContext();
       
       if (context.createDynamicsCompressor) {
           // Create dynamics compressor to sweeten the overall mix.

--- a/samples/audio/convolution-effects.html
+++ b/samples/audio/convolution-effects.html
@@ -54,8 +54,7 @@ Real-time Convolution Effects
 // Events
 
 // Temporary patch until all browsers support unprefixed context.
-if (window.hasOwnProperty('AudioContext') && !window.hasOwnProperty('webkitAudioContext'))
-    window.webkitAudioContext = AudioContext;
+AudioContext = AudioContext || webkitAudioContext;
 
 // init() once the page has finished loading.
 window.onload = init;
@@ -367,7 +366,7 @@ function initPresets() {
 }
 
 function init() {
-    context = new webkitAudioContext();
+    context = new AudioContext();
     
     convolver = context.createConvolver();
     source = context.createBufferSource();

--- a/samples/audio/dj.html
+++ b/samples/audio/dj.html
@@ -51,8 +51,7 @@ Digital DJ
 <script type="text/javascript">
 
 // Temporary patch until all browsers support unprefixed context.
-if (window.hasOwnProperty('AudioContext') && !window.hasOwnProperty('webkitAudioContext'))
-    window.webkitAudioContext = AudioContext;
+AudioContext = AudioContext || webkitAudioContext;
 
 // init() once the page has finished loading.
 window.onload = init;
@@ -329,7 +328,7 @@ function draw() {
 
 function init() {
     // Initialize audio
-    context = new webkitAudioContext();
+    context = new AudioContext();
     
 
     // Create post-compressor gain node.

--- a/samples/audio/doppler.html
+++ b/samples/audio/doppler.html
@@ -52,8 +52,7 @@ Doppler Shift Demo
 <script type="text/javascript">
 
 // Temporary patch until all browsers support unprefixed context.
-if (window.hasOwnProperty('AudioContext') && !window.hasOwnProperty('webkitAudioContext'))
-    window.webkitAudioContext = AudioContext;
+AudioContext = AudioContext || webkitAudioContext;
 
 // init() once the page has finished loading.
 window.onload = init;
@@ -404,7 +403,7 @@ function addSliders() {
  * Start doppler demo
  */
  function init() {
-     context = new webkitAudioContext();
+     context = new AudioContext();
      
      masterGainNode = context.createGain();
      dryGainNode = context.createGain();

--- a/samples/audio/javascript-processing.html
+++ b/samples/audio/javascript-processing.html
@@ -62,8 +62,7 @@ Javascript Processing using WebGL
 o3djs.require('o3djs.shader');
 
 // Temporary patch until all browsers support unprefixed context.
-if (window.hasOwnProperty('AudioContext') && !window.hasOwnProperty('webkitAudioContext'))
-    window.webkitAudioContext = AudioContext;
+AudioContext = AudioContext || webkitAudioContext;
 
 // init() once the page has finished loading.
 window.onload = init;
@@ -168,7 +167,7 @@ function draw() {
 }
 
 function initAudio() {
-    context = new webkitAudioContext();
+    context = new AudioContext();
     source = context.createBufferSource();
 
     // This AudioNode will do the amplitude modulation effect directly in JavaScript

--- a/samples/audio/o3d-webgl-samples/pool.html
+++ b/samples/audio/o3d-webgl-samples/pool.html
@@ -163,8 +163,7 @@ var mediumCount = 0;
 var hardCount = 0;
 
 // Temporary patch until all browsers support unprefixed context.
-if (window.hasOwnProperty('AudioContext') && !window.hasOwnProperty('webkitAudioContext'))
-    window.webkitAudioContext = AudioContext;
+AudioContext = AudioContext || webkitAudioContext;
 
 function updateInfo() {
  var info = document.getElementById('info');
@@ -1225,7 +1224,7 @@ function initClient() {
 
 function initAudio() {
     // Audio init
-    context = new webkitAudioContext();
+    context = new AudioContext();
     
     // Create compressor to sweeten overall mix
     if (context.createDynamicsCompressor) {

--- a/samples/audio/shiny-drum-machine.html
+++ b/samples/audio/shiny-drum-machine.html
@@ -49,8 +49,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // init() once the page has finished loading.
 
 // Temporary patch until all browsers support unprefixed context.
-if (window.hasOwnProperty('AudioContext') && !window.hasOwnProperty('webkitAudioContext'))
-    window.webkitAudioContext = AudioContext;
+AudioContext = AudioContext || webkitAudioContext;
 
 window.onload = init;
 
@@ -448,7 +447,7 @@ function init() {
         
     startLoadingAssets();
 
-    context = new webkitAudioContext();
+    context = new AudioContext();
 
     var finalMixNode;
     if (context.createDynamicsCompressor) {

--- a/samples/audio/simple.html
+++ b/samples/audio/simple.html
@@ -52,8 +52,7 @@ Panning/Reverb
 <script type="text/javascript">
 
 // Temporary patch until all browsers support unprefixed context.
-if (window.hasOwnProperty('AudioContext') && !window.hasOwnProperty('webkitAudioContext'))
-    window.webkitAudioContext = AudioContext;
+AudioContext = AudioContext || webkitAudioContext;
 
 // init() once the page has finished loading.
 window.onload = init;
@@ -281,7 +280,7 @@ function setSourceBuffer(buffer) {
      canvas2.addEventListener("mouseup", handleMouseUp, true);
 
      // Initialize audio
-     context = new webkitAudioContext();
+     context = new AudioContext();
 
      dryGainNode = context.createGain();
      wetGainNode = context.createGain();

--- a/samples/audio/subtractive.html
+++ b/samples/audio/subtractive.html
@@ -67,8 +67,7 @@ o3djs.require('o3djs.shader');
 
 window.onload = init;
 
-if (window.hasOwnProperty('AudioContext') && !window.hasOwnProperty('webkitAudioContext'))
-    window.webkitAudioContext = AudioContext;
+AudioContext = AudioContext || webkitAudioContext;
 
 var context;
 var waveshaper;
@@ -462,7 +461,7 @@ function onMIDIFailure(error) {
 }
 
 function initAudio() {
-    context = new webkitAudioContext();
+    context = new AudioContext();
     
     noiseBuffer = createNoiseBuffer();
 

--- a/samples/audio/wavetable-synth.html
+++ b/samples/audio/wavetable-synth.html
@@ -55,8 +55,7 @@ WaveTable Synth
 <script type="text/javascript">
 
 // Temporary patch until all browsers support unprefixed context.
-if (window.hasOwnProperty('AudioContext') && !window.hasOwnProperty('webkitAudioContext'))
-    window.webkitAudioContext = AudioContext;
+AudioContext = AudioContext || webkitAudioContext;
 
 window.onload = init;
 
@@ -867,7 +866,7 @@ StaticAudioRouting.prototype.setMainGrunge = function(driveDb) {
 }
 
 function init() {
-    context = new webkitAudioContext();
+    context = new AudioContext();
     staticAudioRouting = new StaticAudioRouting();
     monophonicNote = new Note(staticAudioRouting, true);
 


### PR DESCRIPTION
Chrome canaries will print deprecation warnings about using
webkitAudioContext.  Update examples not to use webkitAudioContext.
I didn't fix all of demos; just the ones linked from index.html are
fixed.