### PR TITLE
Explicit cleanup of finished audio nodes

### DIFF
--- a/samples/audio/box2d-js/box2d-audio.html
+++ b/samples/audio/box2d-js/box2d-audio.html
@@ -113,6 +113,14 @@
           panner.setPosition(posX, posY /*0*/, isQuiet ? +posZ : -posZ);
 
           ping.start(0);
+          var stopTime = context.currentTime + ping.buffer.duration / rate + 1;
+          var cleanupDelay = stopTime + 1 - context.currentTime;
+          ping.stop(stopTime);
+          setTimeout(function() {
+            dryGainNode.disconnect();
+            wetGainNode.disconnect();
+            ping.disconnect();
+          }, cleanupDelay * 1000);
         }
       }
     }

--- a/samples/audio/wavetable-synth.html
+++ b/samples/audio/wavetable-synth.html
@@ -717,6 +717,13 @@ Note.prototype.play = function(wave, wave2, semitone, octave, time) {
         osc2Octave.start(time);
         osc1Octave.stop(offTime);
         osc2Octave.stop(offTime);
+        var cleanupDelay = offTime - osc1.context.currentTime + 1;
+//        console.log('cleanupDelay', cleanupDelay);
+        var self = this;
+        setTimeout(function() {
+            self.noteVolume.disconnect();
+//            console.log('cleanup');
+        }, cleanupDelay * 1000);
     } else {
         if (firstTime) {
             osc1.start(0);


### PR DESCRIPTION
Added explicit cleanup of finished audio nodes. This avoids gradual performance degradation due to lazy garbage collection. By explicitly disconnecting ABSN and other voice-related nodes from the audio graph once they're finished, we can avoid the situation where CPU load keeps increasing although number of playing nodes do not.

If you click garbage collect in the dev tools some of the CPU load goes away so this is probably related to Chrome web audio internal garbage collection.