### PR TITLE
Implemented filter ADSR logic and volume and filter ADSR GUI controls.

### DIFF
--- a/poly-synth/index.html
+++ b/poly-synth/index.html
@@ -20,15 +20,47 @@ limitations under the License.
     <script src="src/poly-synth-demo.js"></script>
     <script src="src/poly-synth.js"></script>
     <script src="src/poly-synth-voice.js"></script>
+    <style>
+      #container {
+        display: flex;
+        flex-direction: row;
+      }
+      .controls {
+        border-style: solid;
+        margin: 5px;
+      }
+    </style>
   </head>
   <body>
+    <h1>Polyphonic Subtractive Synthesizer</h1>
     <p>
-     The key A on your computer keyboard maps onto the note C, and the letters
-     to the right of A (SDFGHJ) map onto the notes above C in a C major scale
-     (DEFGAB). The letters WETYU map onto the black keys of a piano.
+      The key A on your computer keyboard maps onto the note C, and the letters
+      to the right of A (SDFGHJ) map onto the notes above C in a C major scale
+      (DEFGAB). The letters WETYU map onto the black keys of a piano.
+    </p>
+    <p>
+      The synthesizer constructs voices according to the volume and filter ADSR
+      settings. The volume ADSR modulates the gain of the signal over time, and
+      the filter ADSR modulates the detune of the cutoff filter, meaning the
+      cutoff specifies the filter's starting point and it will detune over
+      time depending on the ADSR settings. A detune amount of 1 means the filter
+      will deviate by at most 2400 cents from the filter cutoff value. For both
+      the volume and filter ADSR,
+      <ul>
+        <li>Attack refers to the number of seconds until the maximum level.</li>
+        <li>Decay refers to the number of seconds between the attack level
+            and the sustain level.</li>
+        <li>Sustain refers to the steady value as the note is pressed as
+            a fraction of the maximum level.</li>
+        <li>Release refers to the number of seconds from releasing the note
+            until a zero value.</li>
+      </ul>
     </p>
     <div id="keyboard"></div>
-    <div id="container"></div>
+    <div id="container">
+      <div id="gainADSR" class="controls"><h2>Volume</h2></div>
+      <div id="filterADSR" class="controls"><h2>Filter</h2></div>
+    </div>
     <p>
       Credit to Stuart Memo for the
       <a href="https://github.com/stuartmemo/qwerty-hancock">keyboard</a>.
@@ -36,7 +68,7 @@ limitations under the License.
     <script>
       const context = new AudioContext();
       let polySynthDemo = new PolySynthDemo(context);
-      polySynthDemo.initializeGUI('container');
+      polySynthDemo.initializeGUI('gainADSR', 'filterADSR');
     </script>
   </body>
 </html>

--- a/poly-synth/index.html
+++ b/poly-synth/index.html
@@ -21,12 +21,11 @@ limitations under the License.
     <script src="src/poly-synth.js"></script>
     <script src="src/poly-synth-voice.js"></script>
     <style>
-      #container {
+      #param-container {
         display: flex;
         flex-direction: row;
       }
       .controls {
-        border-style: solid;
         margin: 5px;
       }
     </style>
@@ -39,13 +38,9 @@ limitations under the License.
       (DEFGAB). The letters WETYU map onto the black keys of a piano.
     </p>
     <p>
-      The synthesizer constructs voices according to the volume and filter ADSR
-      settings. The volume ADSR modulates the gain of the signal over time, and
-      the filter ADSR modulates the detune of the cutoff filter, meaning the
-      cutoff specifies the filter's starting point and it will detune over
-      time depending on the ADSR settings. A detune amount of 1 means the filter
-      will deviate by at most 2400 cents from the filter cutoff value. For both
-      the volume and filter ADSR,
+      The synthesizer constructs voices according to the amplifier and filter
+      ADSR settings. The amplifier ADSR modulates the gain of the signal over
+      time, and the filter ADSR modulates the detune of the cutoff filter.
       <ul>
         <li>Attack refers to the number of seconds until the maximum level.</li>
         <li>Decay refers to the number of seconds between the attack level
@@ -56,10 +51,12 @@ limitations under the License.
             until a zero value.</li>
       </ul>
     </p>
-    <div id="keyboard"></div>
-    <div id="container">
-      <div id="gainADSR" class="controls"><h2>Volume</h2></div>
-      <div id="filterADSR" class="controls"><h2>Filter</h2></div>
+    <div id="synth-container">
+      <div id="keyboard"></div>
+      <div id="param-container">
+        <div id="amp-envelope" class="controls"><h2>Amplifier</h2></div>
+        <div id="filter-envelope" class="controls"><h2>Filter</h2></div>
+      </div>
     </div>
     <p>
       Credit to Stuart Memo for the
@@ -68,7 +65,7 @@ limitations under the License.
     <script>
       const context = new AudioContext();
       let polySynthDemo = new PolySynthDemo(context);
-      polySynthDemo.initializeGUI('gainADSR', 'filterADSR');
+      polySynthDemo.initializeGUI('amp-envelope', 'filter-envelope');
     </script>
   </body>
 </html>

--- a/poly-synth/src/poly-synth-demo.js
+++ b/poly-synth/src/poly-synth-demo.js
@@ -42,24 +42,14 @@ class PolySynthDemo {
 
   /**
    * Initialize GUI components.
-   * @param {String} containerId The ID of the container element (e.g. <div>).
+   * @param {String} gainADSRId The ID of the container for gain ADSR elements
+   *                            (e.g. <div>).
+   * @param {String} filterADSRId The ID of the container for filter
+   *                              ADSR elements.
    */
-  initializeGUI(containerId) {
-    let lowPassSlider_ = new ParamController(
-        containerId, this.polySynth_.setParameter.bind(this.polySynth_), {
-          name: 'Cutoff',
-          id: 'cutoff',
-          type: 'range',
-          min: this.polySynth_.lowPassMinCutoff,
-          max: this.polySynth_.lowPassMaxCutoff,
-          step: 1,
-          default: this.polySynth_.lowPassMaxCutoff,
-        });
-
-    // The maximum gain is set to be larger than 1 to allow for highly filtered
-    // sounds to be audible. It is up to the user to avoid distortion.
+  initializeGUI(gainADSRId, filterADSRId) {
     let masterGainSlider_ =
-        new ParamController(containerId, this.setGain.bind(this), {
+        new ParamController(gainADSRId, this.setGain.bind(this), {
           name: 'Volume',
           id: 'masterGain',
           type: 'range',
@@ -67,6 +57,116 @@ class PolySynthDemo {
           max: 5,
           step: 0.01,
           default: this.masterGain_.gain.value,
+        });
+
+    let gainAttackSlider_ = new ParamController(
+        gainADSRId, this.polySynth_.setParameter.bind(this.polySynth_), {
+          name: 'Attack (s)',
+          id: 'gainAttack',
+          type: 'range',
+          min: this.polySynth_.minAttack,
+          max: this.polySynth_.maxAttack,
+          step: 0.01,
+          default: this.polySynth_.getParameters().gainAttack,
+        });
+
+    let gainDecaySlider_ = new ParamController(
+        gainADSRId, this.polySynth_.setParameter.bind(this.polySynth_), {
+          name: 'Decay (s)',
+          id: 'gainDecay',
+          type: 'range',
+          min: this.polySynth_.minDecay,
+          max: this.polySynth_.maxDecay,
+          step: 0.01,
+          default: this.polySynth_.getParameters().gainDecay,
+        });
+
+    let gainSustainSlider_ = new ParamController(
+        gainADSRId, this.polySynth_.setParameter.bind(this.polySynth_), {
+          name: 'Sustain',
+          id: 'gainSustain',
+          type: 'range',
+          min: this.polySynth_.minSustain,
+          max: this.polySynth_.maxSustain,
+          step: 0.01,
+          default: this.polySynth_.getParameters().gainSustain,
+        });
+
+    let gainReleaseSlider_ = new ParamController(
+        gainADSRId, this.polySynth_.setParameter.bind(this.polySynth_), {
+          name: 'Release (s)',
+          id: 'gainRelease',
+          type: 'range',
+          min: this.polySynth_.minRelease,
+          max: this.polySynth_.maxRelease,
+          step: 0.01,
+          default: this.polySynth_.getParameters().gainRelease,
+        });
+
+    let lowPassSlider_ = new ParamController(
+        filterADSRId, this.polySynth_.setParameter.bind(this.polySynth_), {
+          name: 'Cutoff (hz)',
+          id: 'filterCutoff',
+          type: 'range',
+          min: this.polySynth_.minCutoff,
+          max: this.polySynth_.maxCutoff,
+          step: 1,
+          default: this.polySynth_.getParameters().filterCutoff,
+        });
+
+    let filterAttackSlider_ = new ParamController(
+        filterADSRId, this.polySynth_.setParameter.bind(this.polySynth_), {
+          name: 'Attack (s)',
+          id: 'filterAttack',
+          type: 'range',
+          min: this.polySynth_.minAttack,
+          max: this.polySynth_.maxAttack,
+          step: 0.01,
+          default: this.polySynth_.getParameters().filterAttack,
+        });
+
+    let filterDecaySlider_ = new ParamController(
+        filterADSRId, this.polySynth_.setParameter.bind(this.polySynth_), {
+          name: 'Decay (s)',
+          id: 'filterDecay',
+          type: 'range',
+          min: this.polySynth_.minDecay,
+          max: this.polySynth_.maxDecay,
+          step: 0.01,
+          default: this.polySynth_.getParameters().filterDecay,
+        });
+
+    let filterSustainSlider_ = new ParamController(
+        filterADSRId, this.polySynth_.setParameter.bind(this.polySynth_), {
+          name: 'Sustain',
+          id: 'filterSustain',
+          type: 'range',
+          min: this.polySynth_.minSustain,
+          max: this.polySynth_.maxSustain,
+          step: 0.01,
+          default: this.polySynth_.getParameters().filterSustain,
+        });
+
+    let filterReleaseSlider_ = new ParamController(
+        filterADSRId, this.polySynth_.setParameter.bind(this.polySynth_), {
+          name: 'Release (s)',
+          id: 'filterRelease',
+          type: 'range',
+          min: this.polySynth_.minRelease,
+          max: this.polySynth_.maxRelease,
+          step: 0.01,
+          default: this.polySynth_.getParameters().filterRelease,
+        });
+
+    let filterDetuneSlider_ = new ParamController(
+        filterADSRId, this.polySynth_.setParameter.bind(this.polySynth_), {
+          name: 'Detune Amount',
+          id: 'filterDetuneAmount',
+          type: 'range',
+          min: this.polySynth_.minDetuneAmount,
+          max: this.polySynth_.maxDetuneAmount,
+          step: 0.01,
+          default: this.polySynth_.getParameters().filterDetuneAmount,
         });
   }
 
@@ -76,7 +176,7 @@ class PolySynthDemo {
    * @param {Number} value The new gain.
    */
   setGain(value) {
-    this.masterGain_.gain.value = parseFloat(value);
+    this.masterGain_.gain.value = value;
   }
 
   /**

--- a/poly-synth/src/poly-synth-demo.js
+++ b/poly-synth/src/poly-synth-demo.js
@@ -168,6 +168,17 @@ class PolySynthDemo {
           step: 0.01,
           default: this.polySynth_.getParameters().filterDetuneAmount,
         });
+
+    let filterQSlider_ = new ParamController(
+        filterADSRId, this.polySynth_.setParameter.bind(this.polySynth_), {
+          name: 'Q',
+          id: 'filterQ',
+          type: 'range',
+          min: this.polySynth_.minQ,
+          max: this.polySynth_.maxQ,
+          step: 0.01,
+          default: this.polySynth_.getParameters().Q,
+        });
   }
 
   /**

--- a/poly-synth/src/poly-synth-demo.js
+++ b/poly-synth/src/poly-synth-demo.js
@@ -114,6 +114,17 @@ class PolySynthDemo {
           default: this.polySynth_.getParameters().filterCutoff,
         });
 
+    let filterQSlider_ = new ParamController(
+        filterADSRId, this.polySynth_.setParameter.bind(this.polySynth_), {
+          name: 'Q (dB)',
+          id: 'filterQ',
+          type: 'range',
+          min: this.polySynth_.minQ,
+          max: this.polySynth_.maxQ,
+          step: 0.01,
+          default: this.polySynth_.getParameters().Q,
+        });
+
     let filterAttackSlider_ = new ParamController(
         filterADSRId, this.polySynth_.setParameter.bind(this.polySynth_), {
           name: 'Attack (s)',
@@ -167,17 +178,6 @@ class PolySynthDemo {
           max: this.polySynth_.maxDetuneAmount,
           step: 0.01,
           default: this.polySynth_.getParameters().filterDetuneAmount,
-        });
-
-    let filterQSlider_ = new ParamController(
-        filterADSRId, this.polySynth_.setParameter.bind(this.polySynth_), {
-          name: 'Q',
-          id: 'filterQ',
-          type: 'range',
-          min: this.polySynth_.minQ,
-          max: this.polySynth_.maxQ,
-          step: 0.01,
-          default: this.polySynth_.getParameters().Q,
         });
   }
 

--- a/poly-synth/src/poly-synth-voice.js
+++ b/poly-synth/src/poly-synth-voice.js
@@ -39,9 +39,11 @@ class PolySynthVoice {
 
     this.oscillatorA_ = new OscillatorNode(
         this.context_, {frequency: frequency, type: 'sawtooth'});
-    this.lowPassFilter_ = new BiquadFilterNode(
-        this.context_,
-        {frequency: this.parameters_.filterCutoff, type: 'lowpass'});
+    this.lowPassFilter_ = new BiquadFilterNode(this.context_, {
+      frequency: this.parameters_.filterCutoff,
+      type: 'lowpass',
+      Q: this.parameters_.filterQ
+    });
 
     this.output = new GainNode(this.context_);
     this.oscillatorA_.connect(this.lowPassFilter_).connect(this.output);
@@ -59,10 +61,8 @@ class PolySynthVoice {
     // Ramp to full amplitude in attack (s) and to sustain in decay (s).
     const t = this.context_.currentTime;
     const timeToFullAmplitude = t + this.parameters_.gainAttack;
-
-    // |timeToGainSustain| must be later than |timeToFullAmplitude|.
     const timeToGainSustain =
-        timeToFullAmplitude + this.parameters_.gainDecay + 0.001;
+        timeToFullAmplitude + this.parameters_.gainDecay;
 
     this.output.gain.setValueAtTime(0, t);
     this.output.gain.linearRampToValueAtTime(1, timeToFullAmplitude);
@@ -81,12 +81,13 @@ class PolySynthVoice {
 
     const timeToFullDetune = t + this.parameters_.filterAttack;
     const timeToDetuneSustain
-        = timeToFullDetune + this.parameters_.filterDecay + 0.001;
+        = timeToFullDetune + this.parameters_.filterDecay;
 
     this.lowPassFilter_.detune.linearRampToValueAtTime(
-        amountOfFilterDetuneInCents, timeToFullDetune);
-    this.lowPassFilter_.detune.linearRampToValueAtTime(
         amountOfSustainDetuneInCents, timeToDetuneSustain);
+    this.lowPassFilter_.detune.linearRampToValueAtTime(
+        amountOfFilterDetuneInCents, timeToFullDetune);
+
   }
 
   /**

--- a/poly-synth/src/poly-synth-voice.js
+++ b/poly-synth/src/poly-synth-voice.js
@@ -31,7 +31,7 @@ class PolySynthVoice {
     this.synth_ = synth;
     this.context_ = context;
     this.parameters_ = synth.getParameters();
-    
+
     // The name of the note is used as an argument in the
     // |this.synth_.endNote()| callback.
     this.noteName_ = noteName;
@@ -41,7 +41,7 @@ class PolySynthVoice {
         this.context_, {frequency: frequency, type: 'sawtooth'});
     this.lowPassFilter_ = new BiquadFilterNode(
         this.context_,
-        {frequency: this.parameters_.cutoff, type: 'lowpass'});
+        {frequency: this.parameters_.filterCutoff, type: 'lowpass'});
 
     this.output = new GainNode(this.context_);
     this.oscillatorA_.connect(this.lowPassFilter_).connect(this.output);
@@ -58,12 +58,35 @@ class PolySynthVoice {
   start() {
     // Ramp to full amplitude in attack (s) and to sustain in decay (s).
     const t = this.context_.currentTime;
-    const timeToFullAmplitude = t + this.parameters_.attack;
-    const timeToSustain = timeToFullAmplitude + this.parameters_.decay;
+    const timeToFullAmplitude = t + this.parameters_.gainAttack;
+
+    // |timeToGainSustain| must be later than |timeToFullAmplitude|.
+    const timeToGainSustain =
+        timeToFullAmplitude + this.parameters_.gainDecay + 0.001;
+
     this.output.gain.setValueAtTime(0, t);
     this.output.gain.linearRampToValueAtTime(1, timeToFullAmplitude);
     this.output.gain.linearRampToValueAtTime(
-        this.parameters_.sustain, timeToSustain);
+        this.parameters_.gainSustain, timeToGainSustain);
+
+    // The detune of the filter reaches its peak amount specified by
+    // |filterDetuneAmount| (where 1 corresponds to 2400 cents detuning) in
+    // |filterAttack| seconds. It then decays to a fraction of that amount as
+    // specified by |filterSustain| in |filterDecay| seconds.
+    const standardFilterDetuneInCents = 2400;
+    const amountOfFilterDetuneInCents =
+        standardFilterDetuneInCents * this.parameters_.filterDetuneAmount;
+    const amountOfSustainDetuneInCents =
+        standardFilterDetuneInCents * this.parameters_.filterSustain;
+
+    const timeToFullDetune = t + this.parameters_.filterAttack;
+    const timeToDetuneSustain
+        = timeToFullDetune + this.parameters_.filterDecay + 0.001;
+
+    this.lowPassFilter_.detune.linearRampToValueAtTime(
+        amountOfFilterDetuneInCents, timeToFullDetune);
+    this.lowPassFilter_.detune.linearRampToValueAtTime(
+        amountOfSustainDetuneInCents, timeToDetuneSustain);
   }
 
   /**
@@ -73,9 +96,16 @@ class PolySynthVoice {
     // Cancel scheduled audio param changes, and fade note according to
     // release time.
     const t = this.context_.currentTime;
-    const timeToZeroAmplitude = t + this.parameters_.release;
+    const timeToZeroAmplitude = t + this.parameters_.gainRelease;
     this.output.gain.cancelAndHoldAtTime(t);
     this.output.gain.linearRampToValueAtTime(0, timeToZeroAmplitude);
+
+    // Fade detune for filter to 0 according to release time.
+    const timeToZeroDetune = t + this.parameters_.filterRelease;
+    this.lowPassFilter_.detune.cancelAndHoldAtTime(t);
+    this.lowPassFilter_.detune.linearRampToValueAtTime(
+        0, timeToZeroDetune);
+
     this.oscillatorA_.stop(timeToZeroAmplitude);
   }
 }

--- a/poly-synth/src/poly-synth.js
+++ b/poly-synth/src/poly-synth.js
@@ -32,15 +32,38 @@ class PolySynth {
     this.releasedVoices_ = [];
 
     // The maximum and minimum cutoffs are experimentally determined.
-    this.lowPassMaxCutoff = 16000;
-    this.lowPassMinCutoff = 60;
+    this.maxCutoff = 16000;
+    this.minCutoff = 60;
 
+    // The maximum and minimum ADSR values refer to the ADSR for the gain as
+    // well as the ADSR for the filter. These values are experimentally
+    // determined.
+    this.maxAttack = 10;
+    this.minAttack = 0;
+    this.minSustain = 0.1;
+    this.maxSustain = 1;
+    this.minDecay = 0;
+    this.maxDecay = 10;
+    this.minRelease = 0;
+    this.maxRelease = 10;
+
+    // A detune amount of 1 will correspond to 2400 cents detuning from the
+    // cutoff value.
+    this.minDetuneAmount = 0;
+    this.maxDetuneAmount = 5;
+
+    // The initial values for the parameters are experimentally determined.
     this.parameters_ = {
-      cutoff: this.lowPassMaxCutoff,
-      attack: 0,
-      decay: 0,
-      sustain: 0.1,
-      release: 0
+      filterCutoff: 440,
+      gainAttack: this.minAttack,
+      gainDecay: this.minDecay,
+      gainSustain: this.minSustain,
+      gainRelease: this.minRelease,
+      filterAttack: 1,
+      filterDecay: 1,
+      filterSustain: this.minSustain,
+      filterRelease: this.minRelease,
+      filterDetuneAmount: 1
     };
 
     // The client is responsible for connecting |this.output| to a destination.

--- a/poly-synth/src/poly-synth.js
+++ b/poly-synth/src/poly-synth.js
@@ -55,14 +55,16 @@ class PolySynth {
     this.minDetuneAmount = 0;
     this.maxDetuneAmount = 5;
 
-    this.minQ = 0;
-    this.maxQ = 100;
+    // Q for the low pass filter is in dB and controls how peaked the response
+    // is around the cutoff frequency.
+    this.minQ = -50;
+    this.maxQ = 50;
 
     // The initial values for the parameters are experimentally determined.
     this.parameters_ = {
-      gainAttack: 0,
+      gainAttack: 0.1,
       gainDecay: this.minDecay,
-      gainSustain: this.minSustain,
+      gainSustain: 0.5,
       gainRelease: 0.1,
       filterCutoff: 440,
       filterQ: this.minQ,
@@ -79,8 +81,8 @@ class PolySynth {
   
   /**
    * Returns parameters that affect how a voice is constructed.
-   * @returns {Object} parameters Parameters which affect the output of a voice
-   *                              if set before the voice is constructed.
+   * @returns {Object} parameters K-rate parameters which affect the output of a
+   *                              voice if set before the voice is constructed.
    * @returns {Number} parameters.gainAttack Seconds until full amplitude.
    * @returns {Number} parameters.gainDecay Seconds between full level and
    *                                        sustain and level.

--- a/poly-synth/src/poly-synth.js
+++ b/poly-synth/src/poly-synth.js
@@ -42,7 +42,10 @@ class PolySynth {
     this.minAttack = 0;
     this.minSustain = 0.1;
     this.maxSustain = 1;
-    this.minDecay = 0;
+
+    // The minimum decay is > 0 since there will be a conflict if the time to
+    // the sustain and time to maximum level are identical.
+    this.minDecay = 0.01;
     this.maxDecay = 10;
     this.minRelease = 0;
     this.maxRelease = 10;
@@ -52,13 +55,17 @@ class PolySynth {
     this.minDetuneAmount = 0;
     this.maxDetuneAmount = 5;
 
+    this.minQ = 0;
+    this.maxQ = 100;
+
     // The initial values for the parameters are experimentally determined.
     this.parameters_ = {
-      filterCutoff: 440,
-      gainAttack: this.minAttack,
+      gainAttack: 0,
       gainDecay: this.minDecay,
       gainSustain: this.minSustain,
-      gainRelease: this.minRelease,
+      gainRelease: 0.1,
+      filterCutoff: 440,
+      filterQ: this.minQ,
       filterAttack: 1,
       filterDecay: 1,
       filterSustain: this.minSustain,
@@ -74,12 +81,24 @@ class PolySynth {
    * Returns parameters that affect how a voice is constructed.
    * @returns {Object} parameters Parameters which affect the output of a voice
    *                              if set before the voice is constructed.
-   * @returns {Number} parameters.attack Seconds until full amplitude.
-   * @returns {Number} parameters.decay Seconds until sustain level.
-   * @returns {Number} parameters.sustain The steady amplitude of the note as it
-   *                                      is pressed.
-   * @returns {Number} parameters.release Seconds between the release of a note
-   *                                      and zero amplitude.
+   * @returns {Number} parameters.gainAttack Seconds until full amplitude.
+   * @returns {Number} parameters.gainDecay Seconds between full level and
+   *                                        sustain and level.
+   * @returns {Number} parameters.gainSustain The steady amplitude of the note
+   *                                          as it is pressed.
+   * @returns {Number} parameters.gainRelease Seconds between the release of a
+   *                                          note and zero amplitude.
+   * @returns {Number} parameters.filterCutoff The cutoff of the low pass
+   *                                           filter.
+   * @returns {Number} parameters.filterQ The peak of the response at the cutoff
+   *                                      frequency.
+   * @returns {Number} parameters.filterAttack Seconds until full detune.
+   * @returns {Number} parameters.filterDecay Seconds between full detune and
+   *                                          sustain detune.
+   * @returns {Number} parameters.filterSustain The steady detune level as a
+   *                                            note is pressed.
+   * @returns {Number} parameters.filterRelease Seconds betweeen the release of
+   *                                            a note and zero detune.
    */
   getParameters() {
     return this.parameters_;


### PR DESCRIPTION
This PR resolves [issue #100 ](https://github.com/GoogleChrome/web-audio-samples/issues/100). 
- poly-synth/index.html now has containers for filter and volume ADSR.
- poly-synth/src/poly-synth-demo.js now adds GUI elements for controlling filter and volume ADSR.
- poly-synth/src/poly-synth.js now has default values for filter and volume ADSR.
- poly-synth/src/poly-synth-voice.js now implements logic for filter ADSR.

The demo can be found [here](http://rawgit.com/GoogleChrome/web-audio-samples/55e6838d614479cfe39ea8b734005d4888079fb4/poly-synth/index.html). 

The parameters currently do not support nonlinear scaling. This is a desirable feature and entails modifying audio-worklet/lib/param-controllerer.js. This should be done in a separate PR, and is listed in issue #106 