### PR TITLE
Noise gate demo integrated with the worklet

### DIFF
--- a/audio-worklet/noisegate.html
+++ b/audio-worklet/noisegate.html
@@ -75,9 +75,7 @@ limitations under the License.
       
       if (workletIsAvailable) {
         window.audioWorklet.addModule('src/noisegate-audio-worklet.js')
-            .then(() => {
-                beginNoisegateDemo();
-            });
+            .then(beginNoisegateDemo());
       } else {
         beginNoisegateDemo();
       }

--- a/audio-worklet/noisegate.html
+++ b/audio-worklet/noisegate.html
@@ -75,7 +75,7 @@ limitations under the License.
       
       if (workletIsAvailable) {
         window.audioWorklet.addModule('src/noisegate-audio-worklet.js')
-            .then(beginNoisegateDemo());
+            .then(beginNoisegateDemo);
       } else {
         beginNoisegateDemo();
       }

--- a/audio-worklet/noisegate.html
+++ b/audio-worklet/noisegate.html
@@ -30,6 +30,7 @@ limitations under the License.
     <script src="lib/source-controller.js"></script>
     <script src="lib/param-controller.js"></script>
     <script src="src/noisegate-demo.js"></script>
+    <script src="lib/audio-worklet-helper.js"></script>
   </head>
   <body>
     <h1>Noise Gate</h1>
@@ -54,20 +55,33 @@ limitations under the License.
       between pauses at a threshold of -40db. If you hear glitching, try
       adjusting the attack and release settings.
     </p>
+    <p>
+      If your browser supports the AudioWorklet node, you can switch between
+      the ScriptProcessor and AudioWorklet NoiseGate implementations.
+    </p>
     <div id="container"></div>
     Noise Gate is <button id="bypassButton">Active</button>
     <form>
       <input type="radio" name="node" id="scriptProcessorButton" checked>
           Script Processor<br>
-      <input type="radio" name="node" id="workletButton" value="worklet">
+      <input type="radio" name="node" id="workletButton">
           Audio Worklet<br>
     </form>
     <script>
-      // TODO: Implement Audio Worklet support. For now, |workletIsAvailable|
-      // must be false.
-      const workletIsAvailable = false;
-      beginNoisegateDemo();
+      // If the browser implements AudioWorklet, the demo enables the user to
+      // switch between audio worklet and script processor implementations of
+      // the noise gate.
+      const workletIsAvailable = AudioWorkletHelper.isAvailable();
       
+      if (workletIsAvailable) {
+        window.audioWorklet.addModule('src/noisegate-audio-worklet.js')
+            .then(() => {
+                beginNoisegateDemo();
+            });
+      } else {
+        beginNoisegateDemo();
+      }
+
       function beginNoisegateDemo() {
         const context = new AudioContext();
         let demo = new NoisegateDemo(context, workletIsAvailable);

--- a/audio-worklet/src/noisegate-demo.js
+++ b/audio-worklet/src/noisegate-demo.js
@@ -205,13 +205,13 @@ class NoisegateDemo {
 
   workletSelected() {
     // Switching occurs 10ms into the future for thread synchronization.
-    const t = this.context_.currentTime + 0.01;
+    const t = this.context_.currentTime;
     this.workletGain_.gain.setValueAtTime(1, t);
     this.scriptProcessorGain_.gain.setValueAtTime(0, t);
   }
 
   scriptProcessorSelected() {
-    const t = this.context_.currentTime + 0.01;
+    const t = this.context_.currentTime;
     this.scriptProcessorGain_.gain.setValueAtTime(1, t);
     this.workletGain_.gain.setValueAtTime(0, t);
   }
@@ -279,7 +279,7 @@ class NoisegateDemo {
           this.attackSlider_.disable();
           this.releaseSlider_.disable();
           this.thresholdSlider_.disable();
-        }
+        };
 
     this.noiseSource_.start();
     this.speechSource_.start();

--- a/audio-worklet/src/noisegate-demo.js
+++ b/audio-worklet/src/noisegate-demo.js
@@ -49,7 +49,7 @@ class NoisegateDemo {
     this.threshold_ = -40;
     this.thresholdMin_ = -100;
     this.thresholdMax_ = 0;
-    
+
     if (this.workletIsAvailable_) {
       this.noisegateAudioWorklet_ =
           new AudioWorkletNode(this.context_, 'noisegate-audio-worklet');
@@ -57,32 +57,29 @@ class NoisegateDemo {
       // The script processor is used by default, and if workletGain_.gain is 0,
       // then scriptProcessorGain_.gain is 1, and vice versa.
       this.workletGain_ = new GainNode(this.context_, {gain: 0});
-      this.speechAndNoiseSummingJunction_.connect(
-          this.noisegateAudioWorklet_).connect(
-          this.workletGain_).connect(
-          this.activeNoisegateRoute_);
+      this.speechAndNoiseSummingJunction_.connect(this.noisegateAudioWorklet_)
+          .connect(this.workletGain_)
+          .connect(this.activeNoisegateRoute_);
     }
 
     const scriptProcessorBufferSize = 4096;
     this.noisegateScriptProcessor_ = new NoiseGate(this.context_, {
-        channelCount: 1,
-        attack: this.attack_,
-        release: this.release_,
-        threshold: this.threshold_
+      channelCount: 1,
+      attack: this.attack_,
+      release: this.release_,
+      threshold: this.threshold_
     });
     this.scriptProcessorGain_ = new GainNode(this.context_);
 
     this.noiseGain_.connect(this.speechAndNoiseSummingJunction_);
-    this.speechAndNoiseSummingJunction_.connect(
-        this.bypassNoisegateRoute_).connect(
-        this.masterGain_);
+    this.speechAndNoiseSummingJunction_.connect(this.bypassNoisegateRoute_)
+        .connect(this.masterGain_);
 
     this.speechAndNoiseSummingJunction_.connect(
         this.noisegateScriptProcessor_.input);
-    this.noisegateScriptProcessor_.output.connect(
-        this.scriptProcessorGain_).connect(
-        this.activeNoisegateRoute_).connect(
-        this.masterGain_);
+    this.noisegateScriptProcessor_.output.connect(this.scriptProcessorGain_)
+        .connect(this.activeNoisegateRoute_)
+        .connect(this.masterGain_);
 
     this.masterGain_.connect(this.context_.destination);
 
@@ -111,8 +108,8 @@ class NoisegateDemo {
    * @param {String} scriptProcessorButtonId ID of scriptProcessor radio button.
    * @param {String} bypassButtonId ID of bypass button.
    */
-  initializeGUI(containerId, workletButtonId, scriptProcessorButtonId,
-                bypassButtonId) {
+  initializeGUI(
+      containerId, workletButtonId, scriptProcessorButtonId, bypassButtonId) {
     this.sourceButton_ = new SourceController(
         containerId, this.start.bind(this), this.stop.bind(this));
 
@@ -168,13 +165,13 @@ class NoisegateDemo {
           default: 0,
           name: 'Noise Volume'
         });
-     
+
     let workletButton = document.getElementById(workletButtonId);
     if (this.workletIsAvailable_)
       workletButton.addEventListener('click', this.workletSelected.bind(this));
     else
       workletButton.disabled = true;
-    
+
     document.getElementById(scriptProcessorButtonId)
         .addEventListener('click', this.scriptProcessorSelected.bind(this));
 
@@ -276,12 +273,13 @@ class NoisegateDemo {
     this.noiseSource_.connect(this.noiseGain_);
     this.speechSource_.connect(this.speechAndNoiseSummingJunction_);
 
-    this.speechSource_.onended = () => {
-      this.sourceButton_.enable();
-      this.attackSlider_.disable();
-      this.releaseSlider_.disable();
-      this.thresholdSlider_.disable();
-    }
+    this.speechSource_.onended =
+        () => {
+          this.sourceButton_.enable();
+          this.attackSlider_.disable();
+          this.releaseSlider_.disable();
+          this.thresholdSlider_.disable();
+        }
 
     this.noiseSource_.start();
     this.speechSource_.start();


### PR DESCRIPTION
In this PR, audio-worklet/noisegate.html and audio-worklet/src/noisegate-demo.js have been modified to support audio-worklet/src/noisegate-audio-worklet.js. The audio worklet version only works if the browser supports audio worklets. 

The demo can be found [here](http://rawgit.com/GoogleChrome/web-audio-samples/2d62ef30ef41c7850c394428767c0e53a68ee695/audio-worklet/noisegate.html).