### PR TITLE
Added three master effects to the poly-synth

### DIFF
--- a/poly-synth/index.html
+++ b/poly-synth/index.html
@@ -17,6 +17,7 @@ limitations under the License.
     <title>Polyphonic Subtractive Synth</title>
     <script src="third-party/qwerty-hancock.min.js"></script>
     <script src="../audio-worklet/lib/param-controller.js"></script>
+    <script src="../audio-worklet/src/bitcrusher-script-processor.js"></script>
     <script src="src/poly-synth-demo.js"></script>
     <script src="src/poly-synth.js"></script>
     <script src="src/poly-synth-voice.js"></script>
@@ -33,39 +34,49 @@ limitations under the License.
   <body>
     <h1>Polyphonic Subtractive Synthesizer</h1>
     <p>
-      The key A on your computer keyboard maps onto the note C, and the letters
-      to the right of A (SDFGHJ) map onto the notes above C in a C major scale
-      (DEFGAB). The letters WETYU map onto the black keys of a piano.
-    </p>
+    The key A on your computer keyboard maps onto the note C, and the letters
+    to the right of A (SDFGHJ) map onto the notes above C in a C major scale
+    (DEFGAB). The letters WETYU map onto the black keys of a piano.
     <p>
-      The synthesizer constructs voices according to the amplifier and filter
-      ADSR settings. The amplifier ADSR modulates the gain of the signal over
-      time, and the filter ADSR modulates the detune of the cutoff filter.
-      <ul>
-        <li>Attack refers to the number of seconds until the maximum level.</li>
-        <li>Decay refers to the number of seconds between the attack level
-            and the sustain level.</li>
-        <li>Sustain refers to the steady value as the note is pressed as
-            a fraction of the maximum level.</li>
-        <li>Release refers to the number of seconds from releasing the note
-            until a zero value.</li>
-      </ul>
-    </p>
+    The synthesizer constructs voices according to the amplifier and filter
+    ADSR settings. The amplifier ADSR modulates the gain of the signal over
+    time, and the filter ADSR modulates the detune of the cutoff filter.
+    <ul>
+      <li>Attack refers to the number of seconds until the maximum level.</li>
+      <li>Decay refers to the number of seconds between the attack level
+          and the sustain level.</li>
+      <li>Sustain refers to the steady value as the note is pressed as
+          a fraction of the maximum level.</li>
+      <li>Release refers to the number of seconds from releasing the note
+          until a zero value.</li>
+    </ul>
+    <p>
+    The combined output of the voices can then be modulated by bitcrushing,
+    convolution, and feedback delay.
     <div id="synth-container">
       <div id="keyboard"></div>
       <div id="param-container">
         <div id="amp-envelope" class="controls"><h2>Amplifier</h2></div>
         <div id="filter-envelope" class="controls"><h2>Filter</h2></div>
+        <div id="bitcrusher" class="controls">
+          <h2>Bitcrusher</h2>
+          Bitcrusher is <button id="bitcrusherBypassButton">Bypassed</button>
+        </div>
+        <div id="convolver" class="controls">
+          <h2>Convolver</h2>
+          <select id="convolverUrls"></select>
+        </div>
+        <div id="feedback" class="controls"><h2>Feedback</h2></div>
       </div>
     </div>
     <p>
       Credit to Stuart Memo for the
       <a href="https://github.com/stuartmemo/qwerty-hancock">keyboard</a>.
-    </p>
     <script>
       const context = new AudioContext();
-      let polySynthDemo = new PolySynthDemo(context);
-      polySynthDemo.initializeGUI('amp-envelope', 'filter-envelope');
+      let polySynthDemo = new PolySynthDemo(
+          context, 'amp-envelope', 'filter-envelope', 'bitcrusher', 'convolver',
+          'convolverUrls', 'feedback');
     </script>
   </body>
 </html>

--- a/poly-synth/index.html
+++ b/poly-synth/index.html
@@ -28,6 +28,9 @@ limitations under the License.
       }
       .controls {
         margin: 5px;
+        width: 150px;
+        display: flex;
+        flex-direction: column;
       }
     </style>
   </head>
@@ -52,31 +55,44 @@ limitations under the License.
     </ul>
     <p>
     The combined output of the voices can then be modulated by bitcrushing,
-    convolution, and feedback delay.
+    reverb, and delay effects.
     <div id="synth-container">
       <div id="keyboard"></div>
       <div id="param-container">
-        <div id="amp-envelope" class="controls"><h2>Amplifier</h2></div>
-        <div id="filter-envelope" class="controls"><h2>Filter</h2></div>
+        <div id="amp-envelope" class="controls">
+          <h2>Amplifier Envelope</h2>
+        </div>
+        <div id="filter" class="controls"><h2>Filter</h2></div>
+        <div id="filter-envelope" class="controls"><h2>
+          Filter Envelope</h2>
+        </div>
         <div id="bitcrusher" class="controls">
           <h2>Bitcrusher</h2>
-          Bitcrusher is <button id="bitcrusherBypassButton">Bypassed</button>
+          <button id="bitcrusherBypassButton">Bypassed</button>
         </div>
-        <div id="convolver" class="controls">
-          <h2>Convolver</h2>
-          <select id="convolverUrls"></select>
+        <div id="delay" class="controls"><h2>Delay</h2></div>
+        <div id="reverb" class="controls">
+          <h2>Reverb</h2>
+          <select id="reverbUrls"></select>
         </div>
-        <div id="feedback" class="controls"><h2>Feedback</h2></div>
+        <div id="volume" class="controls"><h2>Volume</h2></div>
       </div>
     </div>
     <p>
-      Credit to Stuart Memo for the
-      <a href="https://github.com/stuartmemo/qwerty-hancock">keyboard</a>.
+    Credit to Stuart Memo for the
+    <a href="https://github.com/stuartmemo/qwerty-hancock">keyboard</a>.
     <script>
       const context = new AudioContext();
-      let polySynthDemo = new PolySynthDemo(
-          context, 'amp-envelope', 'filter-envelope', 'bitcrusher', 'convolver',
-          'convolverUrls', 'feedback');
+      let polySynthDemo = new PolySynthDemo(context, {
+        gainEnvelopeDivId: 'amp-envelope',
+        filterDivId: 'filter',
+        filterEnvelopeDivId: 'filter-envelope',
+        bitcrusherDivId: 'bitcrusher',
+        reverbDivId: 'reverb',
+        reverbSelectorId: 'reverbUrls',
+        delayDivId: 'delay',
+        volumeDivId: 'volume'
+      });
     </script>
   </body>
 </html>

--- a/poly-synth/src/poly-synth-demo.js
+++ b/poly-synth/src/poly-synth-demo.js
@@ -366,6 +366,7 @@ class PolySynthDemo {
   getImpulseResponseUrls_() {
     let impulseResponseUrls =
         [
+          '../samples/audio/impulse-responses/matrix-reverb1.wav',
           '../samples/audio/impulse-responses/backslap1.wav',
           '../samples/audio/impulse-responses/backwards-4.wav',
           '../samples/audio/impulse-responses/bright-hall.wav',
@@ -384,7 +385,6 @@ class PolySynthDemo {
           '../samples/audio/impulse-responses/filter-telephone.wav',
           '../samples/audio/impulse-responses/imp_sequence.wav',
           '../samples/audio/impulse-responses/impulse-rhythm1.wav',
-          '../samples/audio/impulse-responses/matrix-reverb1.wav',
           '../samples/audio/impulse-responses/matrix6-backwards.wav',
           '../samples/audio/impulse-responses/medium-room1.wav',
           '../samples/audio/impulse-responses/noise-spreader1.wav',

--- a/poly-synth/src/poly-synth-demo.js
+++ b/poly-synth/src/poly-synth-demo.js
@@ -22,163 +22,368 @@ class PolySynthDemo {
   /**
    * @constructor
    * @param {AudioContext} context The audio context.
-   */
-  constructor(context) {
-    this.masterGain_ = new GainNode(context, {gain: 0.5});
-    this.polySynth_ = new PolySynth(context);
-    this.polySynth_.output.connect(this.masterGain_)
-        .connect(context.destination);
-
-    // Initialize a QWERTY keyboard defined in qwerty-hancock.min.js.
-    // The key A on a computer keyboard maps onto the note C, and the letters
-    // to the right of A (SDFGHJ) map onto the notes above C in a C major scale
-    // (DEFGAB). The letters WETYU map onto the black keys of a piano.
-    this.keyboard_ = new QwertyHancock(
-        {id: 'keyboard', width: 600, height: 150, octaves: 2});
-
-    this.keyboard_.keyDown = this.keyDown.bind(this);
-    this.keyboard_.keyUp = this.keyUp.bind(this);
-  }
-
-  /**
-   * Initialize GUI components.
    * @param {String} gainADSRId The ID of the container for gain ADSR elements
    *                            (e.g. <div>).
    * @param {String} filterADSRId The ID of the container for filter
    *                              ADSR elements.
+   * @param {String} bitcrusherId The ID of the container for bitcrusher
+   *                              parameter elements.
+   * @param {String} convolverId The ID of the container for convolver
+   *                             elements.
+   * @param {String} convolverSelectorId The ID of the <select> element for
+   *                             convolver impulse response options.
+   * @param {String} feedbackId The ID of the container for feedback delay
+   *                             elements.
    */
-  initializeGUI(gainADSRId, filterADSRId) {
+  constructor(
+      context, gainADSRId, filterADSRId, bitcrusherId, convolverId,
+      convolverSelectorId, feedbackId) {
+    this.context_ = context;
+    this.gainADSRId_ = gainADSRId;
+    this.filterADSRId_ = filterADSRId;
+    this.bitcrusherId_ = bitcrusherId;
+    this.convolverId_ = convolverId;
+    this.convolverSelectorId_ = convolverSelectorId;
+    this.feedbackId_ = feedbackId;
+
+    this.impulseResponseUrls_ = this.getImpulseResponseUrls_();
+
+    this.masterGain_ = new GainNode(this.context_, {gain: 0.5});
+
+    this.loadImpulseResponses(this.impulseResponseUrls_)
+        .then((impulseResponseBuffers) => {
+          this.impulseResponseBuffers_ = impulseResponseBuffers;
+          
+          this.polySynth_ =
+              new PolySynth(this.context_, impulseResponseBuffers[0]);
+          this.polySynth_.output.connect(this.masterGain_)
+              .connect(this.context_.destination);
+
+          // The QWERTY keyboard is defined in qwerty-hancock.min.js.
+          this.keyboard_ = new QwertyHancock(
+              {id: 'keyboard', width: 600, height: 150, octaves: 2});
+          this.keyboard_.keyDown = this.keyDown.bind(this);
+          this.keyboard_.keyUp = this.keyUp.bind(this);
+          
+          this.initializeAmplifierEnvelopeGUI_(this.gainADSRId_);
+          this.initializeFilterEnvelopeGUI_(this.filterADSRId_);
+          this.initializeBitcrusherGUI_(this.bitcrusherId_);
+          this.initializeConvolverGUI_(
+              this.convolverId_, this.convolverSelectorId_);
+          this.initializeFeedbackDelayGUI_(this.feedbackId_);
+        });
+  }
+
+  async loadImpulseResponses(impulseResponses){
+    let responseBuffers = [];
+    for (let index in impulseResponses) {
+      responseBuffers[index] = await this.loadSound(impulseResponses[index]);
+    }
+    return responseBuffers;
+  }
+
+  async loadSound(url) {
+    const response = await fetch(url);
+    const sound = await response.arrayBuffer();
+    return this.context_.decodeAudioData(sound);
+  }
+
+  initializeAmplifierEnvelopeGUI_(containerId){
     let masterGainSlider_ =
-        new ParamController(gainADSRId, this.setGain.bind(this), {
+        new ParamController(containerId, this.setGain.bind(this), {
           name: 'Volume',
           id: 'masterGain',
           type: 'range',
           min: 0,
           max: 5,
           step: 0.01,
-          default: this.masterGain_.gain.value,
+          default: this.masterGain_.gain.value
         });
 
     let gainAttackSlider_ = new ParamController(
-        gainADSRId, this.polySynth_.setParameter.bind(this.polySynth_), {
+        containerId, this.polySynth_.setParameter.bind(this.polySynth_), {
           name: 'Attack (s)',
           id: 'gainAttack',
           type: 'range',
           min: this.polySynth_.minAttack,
           max: this.polySynth_.maxAttack,
           step: 0.01,
-          default: this.polySynth_.getParameters().gainAttack,
+          default: this.polySynth_.getParameters().gainAttack
         });
 
     let gainDecaySlider_ = new ParamController(
-        gainADSRId, this.polySynth_.setParameter.bind(this.polySynth_), {
+        containerId, this.polySynth_.setParameter.bind(this.polySynth_), {
           name: 'Decay (s)',
           id: 'gainDecay',
           type: 'range',
           min: this.polySynth_.minDecay,
           max: this.polySynth_.maxDecay,
           step: 0.01,
-          default: this.polySynth_.getParameters().gainDecay,
+          default: this.polySynth_.getParameters().gainDecay
         });
 
     let gainSustainSlider_ = new ParamController(
-        gainADSRId, this.polySynth_.setParameter.bind(this.polySynth_), {
+        containerId, this.polySynth_.setParameter.bind(this.polySynth_), {
           name: 'Sustain',
           id: 'gainSustain',
           type: 'range',
           min: this.polySynth_.minSustain,
           max: this.polySynth_.maxSustain,
           step: 0.01,
-          default: this.polySynth_.getParameters().gainSustain,
+          default: this.polySynth_.getParameters().gainSustain
         });
 
     let gainReleaseSlider_ = new ParamController(
-        gainADSRId, this.polySynth_.setParameter.bind(this.polySynth_), {
+        containerId, this.polySynth_.setParameter.bind(this.polySynth_), {
           name: 'Release (s)',
           id: 'gainRelease',
           type: 'range',
           min: this.polySynth_.minRelease,
           max: this.polySynth_.maxRelease,
           step: 0.01,
-          default: this.polySynth_.getParameters().gainRelease,
+          default: this.polySynth_.getParameters().gainRelease
         });
-
+  }
+  
+  initializeFilterEnvelopeGUI_(containerId){
     let lowPassSlider_ = new ParamController(
-        filterADSRId, this.polySynth_.setParameter.bind(this.polySynth_), {
+        containerId, this.polySynth_.setParameter.bind(this.polySynth_), {
           name: 'Cutoff (hz)',
           id: 'filterCutoff',
           type: 'range',
           min: this.polySynth_.minCutoff,
           max: this.polySynth_.maxCutoff,
           step: 1,
-          default: this.polySynth_.getParameters().filterCutoff,
+          default: this.polySynth_.getParameters().filterCutoff
         });
 
     let filterQSlider_ = new ParamController(
-        filterADSRId, this.polySynth_.setParameter.bind(this.polySynth_), {
+        containerId, this.polySynth_.setParameter.bind(this.polySynth_), {
           name: 'Q (dB)',
           id: 'filterQ',
           type: 'range',
           min: this.polySynth_.minQ,
           max: this.polySynth_.maxQ,
           step: 0.01,
-          default: this.polySynth_.getParameters().filterQ,
+          default: this.polySynth_.getParameters().filterQ
         });
 
     let filterAttackSlider_ = new ParamController(
-        filterADSRId, this.polySynth_.setParameter.bind(this.polySynth_), {
+        containerId, this.polySynth_.setParameter.bind(this.polySynth_), {
           name: 'Attack (s)',
           id: 'filterAttack',
           type: 'range',
           min: this.polySynth_.minAttack,
           max: this.polySynth_.maxAttack,
           step: 0.01,
-          default: this.polySynth_.getParameters().filterAttack,
+          default: this.polySynth_.getParameters().filterAttack
         });
 
     let filterDecaySlider_ = new ParamController(
-        filterADSRId, this.polySynth_.setParameter.bind(this.polySynth_), {
+        containerId, this.polySynth_.setParameter.bind(this.polySynth_), {
           name: 'Decay (s)',
           id: 'filterDecay',
           type: 'range',
           min: this.polySynth_.minDecay,
           max: this.polySynth_.maxDecay,
           step: 0.01,
-          default: this.polySynth_.getParameters().filterDecay,
+          default: this.polySynth_.getParameters().filterDecay
         });
 
     let filterSustainSlider_ = new ParamController(
-        filterADSRId, this.polySynth_.setParameter.bind(this.polySynth_), {
+        containerId, this.polySynth_.setParameter.bind(this.polySynth_), {
           name: 'Sustain',
           id: 'filterSustain',
           type: 'range',
           min: this.polySynth_.minSustain,
           max: this.polySynth_.maxSustain,
           step: 0.01,
-          default: this.polySynth_.getParameters().filterSustain,
+          default: this.polySynth_.getParameters().filterSustain
         });
 
     let filterReleaseSlider_ = new ParamController(
-        filterADSRId, this.polySynth_.setParameter.bind(this.polySynth_), {
+        containerId, this.polySynth_.setParameter.bind(this.polySynth_), {
           name: 'Release (s)',
           id: 'filterRelease',
           type: 'range',
           min: this.polySynth_.minRelease,
           max: this.polySynth_.maxRelease,
           step: 0.01,
-          default: this.polySynth_.getParameters().filterRelease,
+          default: this.polySynth_.getParameters().filterRelease
         });
 
     let filterDetuneSlider_ = new ParamController(
-        filterADSRId, this.polySynth_.setParameter.bind(this.polySynth_), {
+        containerId, this.polySynth_.setParameter.bind(this.polySynth_), {
           name: 'Detune Amount',
           id: 'filterDetuneAmount',
           type: 'range',
           min: this.polySynth_.minDetuneAmount,
           max: this.polySynth_.maxDetuneAmount,
           step: 0.01,
-          default: this.polySynth_.getParameters().filterDetuneAmount,
+          default: this.polySynth_.getParameters().filterDetuneAmount
         });
+  }
+  
+  initializeBitcrusherGUI_(containerId){
+    let bitcrusherBitDepthSlider_ = new ParamController(
+        containerId, this.polySynth_.setBitDepth.bind(this.polySynth_), {
+          name: 'Bit Depth',
+          id: 'bitDepth',
+          type: 'range',
+          min: this.polySynth_.minBitDepth,
+          max: this.polySynth_.maxBitDepth,
+          step: 0.01,
+          default: this.polySynth_.bitcrusher.bitDepth
+        });
+    bitcrusherBitDepthSlider_.disable();
+
+    let bitcrusherReductionSlider_ = new ParamController(
+        containerId, this.polySynth_.setReduction.bind(this.polySynth_), {
+          name: 'Reduction',
+          id: 'reduction',
+          type: 'range',
+          min: this.polySynth_.minReduction,
+          max: this.polySynth_.maxReduction,
+          step: 1,
+          default: this.polySynth_.bitcrusher.reduction
+        });
+    bitcrusherReductionSlider_.disable();
+
+    // Sound is not processed by the bitcrusher if in bypass mode.
+    document.getElementById('bitcrusherBypassButton').onclick = (event) => {
+      // Only one of |this.polySynth_.activeBitcrusherRoute_| and
+      // |this.polySynth_.bypassBitcrusherRoute_| has a non-zero gain.
+      if (event.target.textContent === 'Active') {
+        event.target.textContent = 'Bypassed';
+
+        // The change is scheduled slightly into the future to avoid glitching.
+        const t = this.context_.currentTime + 0.01;
+        this.polySynth_.bypassBitcrusherRoute.gain.linearRampToValueAtTime(
+            1, t);
+        this.polySynth_.activeBitcrusherRoute.gain.linearRampToValueAtTime(
+            0, t);
+
+        bitcrusherBitDepthSlider_.disable();
+        bitcrusherReductionSlider_.disable();
+      } else {
+        event.target.textContent = 'Active';
+        const t = this.context_.currentTime + 0.01;
+        this.polySynth_.activeBitcrusherRoute.gain.linearRampToValueAtTime(
+            1, t);
+        this.polySynth_.bypassBitcrusherRoute.gain.linearRampToValueAtTime(
+            0, t);
+
+        bitcrusherBitDepthSlider_.enable();
+        bitcrusherReductionSlider_.enable();
+      }
+    }
+  }
+
+  initializeConvolverGUI_(containerId, selectorId) {
+    let convolverWetnessSlider_ = new ParamController(
+        containerId, this.polySynth_.setConvolverWetness.bind(this.polySynth_),
+        {
+          name: 'Wetness',
+          id: 'wetness',
+          type: 'range',
+          min: 0,
+          max: 1,
+          step: 0.1,
+          default: this.polySynth_.convolverWetness
+        });
+
+    // The synth's convolver node buffer changes depending the selected url.
+    let selector = document.getElementById(selectorId);
+    for (let index in this.impulseResponseUrls_) {
+      let urlParts = this.impulseResponseUrls_[index].split('/');
+      let abbreviatedUrl = urlParts[urlParts.length - 1];
+      let option = document.createElement('option');
+      option.value = index;
+      option.textContent = abbreviatedUrl;
+      selector.appendChild(option);
+    }
+
+    selector.onchange = (event) => {
+      let responseIndex = parseInt(event.target.value);
+      this.polySynth_.setConvolverBuffer(
+          this.impulseResponseBuffers_[responseIndex]);
+
+      // Deselect the target to prevent interference with keyboard.
+      event.target.blur();
+    }
+  }
+
+  initializeFeedbackDelayGUI_(containerId){
+    let feedbackWetnessSlider_ = new ParamController(
+        containerId, this.polySynth_.setFeedbackWetness.bind(this.polySynth_), {
+          name: 'Wetness',
+          id: 'wetness',
+          type: 'range',
+          min: 0,
+          max: 1,
+          step: 0.1,
+          default: this.polySynth_.feedbackWetness
+        });
+
+    let feedbackDelaySlider_ = new ParamController(
+        containerId, this.polySynth_.setFeedbackDelayTime.bind(this.polySynth_), {
+          name: 'Delay',
+          id: 'delay',
+          type: 'range',
+          min: 0,
+          max: 1,
+          step: 0.1,
+          default: this.polySynth_.feedbackDelayTime
+        });
+
+    let feedbackGainSlider_  = new ParamController(
+        containerId, this.polySynth_.setFeedbackGain.bind(this.polySynth_), {
+          name: 'Gain',
+          id: 'feedbackGain',
+          type: 'range',
+          min: 0,
+          max: 1,
+          step: 0.1,
+          default: this.polySynth_.feedbackGain
+        });
+  }
+
+  getImpulseResponseUrls_() {
+    let impulseResponseUrls =
+        [
+          '../samples/audio/impulse-responses/backslap1.wav',
+          '../samples/audio/impulse-responses/backwards-4.wav',
+          '../samples/audio/impulse-responses/bright-hall.wav',
+          '../samples/audio/impulse-responses/chorus-feedback.wav',
+          '../samples/audio/impulse-responses/comb-saw1.wav',
+          '../samples/audio/impulse-responses/comb-square1.wav',
+          '../samples/audio/impulse-responses/cosmic-ping-long.wav',
+          '../samples/audio/impulse-responses/cosmic-ping-longdrive.wav',
+          '../samples/audio/impulse-responses/crackle.wav',
+          '../samples/audio/impulse-responses/diffusor1.wav',
+          '../samples/audio/impulse-responses/echo-chamber.wav',
+          '../samples/audio/impulse-responses/feedback-spring.wav',
+          '../samples/audio/impulse-responses/filter-lopass160.wav',
+          '../samples/audio/impulse-responses/filter-midbandpass.wav',
+          '../samples/audio/impulse-responses/filter-rhythm1.wav',
+          '../samples/audio/impulse-responses/filter-telephone.wav',
+          '../samples/audio/impulse-responses/imp_sequence.wav',
+          '../samples/audio/impulse-responses/impulse-rhythm1.wav',
+          '../samples/audio/impulse-responses/matrix-reverb1.wav',
+          '../samples/audio/impulse-responses/matrix6-backwards.wav',
+          '../samples/audio/impulse-responses/medium-room1.wav',
+          '../samples/audio/impulse-responses/noise-spreader1.wav',
+          '../samples/audio/impulse-responses/peculiar-backwards.wav',
+          '../samples/audio/impulse-responses/sifter.wav',
+          '../samples/audio/impulse-responses/smooth-hall.wav',
+          '../samples/audio/impulse-responses/spatialized1.wav',
+          '../samples/audio/impulse-responses/spreader10-85ms.wav',
+          '../samples/audio/impulse-responses/wildecho-old.wav',
+          '../samples/audio/impulse-responses/zing-long-stereo.wav',
+          '../samples/audio/impulse-responses/zoot.wav'
+        ];
+
+    return impulseResponseUrls;
   }
 
   /**

--- a/poly-synth/src/poly-synth-voice.js
+++ b/poly-synth/src/poly-synth-voice.js
@@ -87,7 +87,6 @@ class PolySynthVoice {
         amountOfSustainDetuneInCents, timeToDetuneSustain);
     this.lowPassFilter_.detune.linearRampToValueAtTime(
         amountOfPeakDetuneInCents, timeToFullDetune);
-
   }
 
   /**

--- a/poly-synth/src/poly-synth.js
+++ b/poly-synth/src/poly-synth.js
@@ -22,8 +22,10 @@ class PolySynth {
   /**
    * @constructor
    * @param {AudioContext} context The audio context.
+   * @param {AudioBuffer} defaultImpulseResponse The default impulse response.
+
    */
-  constructor(context) {
+  constructor(context, defaultImpulseResponse) {
     if (!(context instanceof AudioContext))
       throw context + ' is not a valid audio context.';
 
@@ -60,6 +62,22 @@ class PolySynth {
     this.minQ = -50;
     this.maxQ = 50;
 
+    // The bitcrusher defaults non-information reducing parameters.
+    this.minBitDepth = 1;
+    this.maxBitDepth = 24;
+    this.minReduction = 1;
+    this.maxReduction = 10;
+
+    // By default no feedback is applied. The gain and delay time are
+    // experimentally determined.
+    this.feedbackWetness = 0;
+    this.feedbackGain = 0.5;
+    this.feedbackDelayTime = 0.2;
+
+    // By default no convolution is applied.
+    this.convolverWetness = 1;
+    this.impulseResponse_ = defaultImpulseResponse;
+
     // The initial values for the parameters are experimentally determined.
     this.parameters_ = {
       gainAttack: 0.1,
@@ -72,13 +90,101 @@ class PolySynth {
       filterDecay: 1,
       filterSustain: this.minSustain,
       filterRelease: this.minRelease,
-      filterDetuneAmount: 1
+      filterDetuneAmount: 1,
     };
+
+    // Each voice is connected to |this.voiceOutput_|.
+    this.voiceOutput_ = new GainNode(this.context_);
+
+    // The output of |this.voiceOutput_| is processed by three effects
+    // bitcrusher, feedback delay, and a convolver.
+    let feedbackInputNode = new GainNode(this.context_);
+    let feedbackOutputNode = this.createFeedbackGraph_(feedbackInputNode);
+
+    let bitcrusherInputNode = new GainNode(this.context_);
+    let bitcrusherOutputNode = this.createBitcrusherGraph_(bitcrusherInputNode);
+
+    let convolverInputNode = new GainNode(this.context_);
+    let convolverOutputNode = this.createConvolverGraph_(convolverInputNode);
 
     // The client is responsible for connecting |this.output| to a destination.
     this.output = new GainNode(this.context_);
+
+    // The feedback node occurs prior to the other effects so that the output
+    // of the feedback can be modulated by these components.
+    this.voiceOutput_.connect(feedbackInputNode);
+    feedbackOutputNode.connect(bitcrusherInputNode);
+    bitcrusherOutputNode.connect(convolverInputNode);
+    convolverOutputNode.connect(this.output);
   }
-  
+
+  createFeedbackGraph_(inputNode) {
+    // The sum of the gain of the wet and dry signal is always 1, and the output
+    // always routes through both nodes.
+    this.feedbackWetSignal_ =
+        new GainNode(this.context_, {gain: this.feedbackWetness});
+    this.feedbackDrySignal_ =
+        new GainNode(this.context_, {gain: 1 - this.feedbackWetness});
+    this.feedbackDelayNode_ =
+        new DelayNode(this.context_, {delayTime: this.feedbackDelayTime});
+    this.feedbackGainNode_ =
+        new GainNode(this.context_, {gain: this.feedbackGain});
+    let feedbackEffectOutputNode = new GainNode(this.context_, {gain: 1});
+
+    inputNode.connect(this.feedbackDrySignal_)
+        .connect(feedbackEffectOutputNode);
+
+    // The output of the delay node routes through the wet path as well as a
+    // gain node which echoes the delay node's output back to it at a gain
+    // specified by the user.
+    inputNode.connect(this.feedbackDelayNode_)
+        .connect(this.feedbackWetSignal_)
+        .connect(feedbackEffectOutputNode);
+    this.feedbackDelayNode_.connect(this.feedbackGainNode_)
+        .connect(this.feedbackDelayNode_);
+
+    return feedbackEffectOutputNode;
+  }
+
+  createBitcrusherGraph_(inputNode) {
+    this.bitcrusher = new Bitcrusher(
+        this.context_,
+        {bitDepth: this.maxBitDepth, reduction: this.minReduction});
+
+    // Only one of |this.activeBitcrusherRoute_| and
+    // |this.bypassBitcrusherRoute_| has a non-zero gain
+    this.activeBitcrusherRoute = new GainNode(this.context_, {gain: 0});
+    this.bypassBitcrusherRoute = new GainNode(this.context_, {gain: 1});
+    let bitcrusherOutputNode = new GainNode(this.context_);
+
+    inputNode.connect(this.activeBitcrusherRoute)
+        .connect(this.bitcrusher.input);
+    this.bitcrusher.output.connect(bitcrusherOutputNode);
+    inputNode.connect(this.bypassBitcrusherRoute).connect(bitcrusherOutputNode);
+   
+    return bitcrusherOutputNode;
+  }
+
+  createConvolverGraph_(inputNode) {
+    // The sum of the gain of the wet and dry signal is always 1.
+    this.convolverWetSignal_ =
+        new GainNode(this.context_, {gain: this.convolverWetness});
+    this.convolverDrySignal_ =
+        new GainNode(this.context_, {gain: 1 - this.convolverWetness});
+    this.convolver_ =
+        new ConvolverNode(this.context_, {buffer: this.impulseResponse_});
+    let convolverOutputNode = new GainNode(this.context_);
+
+    inputNode.connect(this.convolver_)
+        .connect(this.convolverWetSignal_)
+        .connect(convolverOutputNode);
+    inputNode.connect(this.convolverDrySignal_)
+        .connect(convolverOutputNode);
+    
+    return convolverOutputNode;
+  }
+
+
   /**
    * Returns parameters that affect how a voice is constructed.
    * @returns {Object} parameters K-rate parameters which affect the output of a
@@ -119,13 +225,71 @@ class PolySynth {
   }
 
   /**
+   * Sets the bit depth of the bitcrusher.
+   * @param {Number} value The new bit depth.
+   */
+  setBitDepth(value) {
+    this.bitcrusher.bitDepth = value;
+  }
+
+  /**
+   * Sets the sample rate reduction of the bit crusher.
+   * @param {Number} value The new sample rate reduction.
+   */
+  setReduction(value) {
+    this.bitcrusher.reduction = value;
+  }
+
+  /**
+   * Set the amount convolution to apply.
+   * @param {Number} value The new gain of |this.convolverWetSignal_|.
+   */
+  setConvolverWetness(value) {
+    this.convolverWetSignal_.gain.value = value;
+    this.convolverDrySignal_.gain.value = 1 - value;
+  }
+
+  /**
+   * Set the impulse response of the convolver node.
+   * @param {AudioBuffer} impulseResponseBuffer The new impulse response buffer.
+   */
+  setConvolverBuffer(impulseResponseBuffer) {
+    this.convolver_.buffer = impulseResponseBuffer;
+  }
+
+  /**
+   * Set the amount feedback delay to apply.
+   * @param {Number} value The new gain of |this.feedbackWetSignal_|.
+   */
+  setFeedbackWetness(value) {
+    this.feedbackWetSignal_.gain.value = value;
+    this.feedbackDrySignal_.gain.value = 1 - value;
+  }
+
+  /**
+   * Sets the delay time of the delay node.
+   * @param {Number} value The new delayTime of |feedbackDelayNode_|.
+   */
+  setFeedbackDelayTime(value) {
+    this.feedbackDelayNode_.delayTime.value = value;
+  }
+
+  /**
+   * Sets the gain of the delay feedback node.
+   * @param {Number} value The new gain of the feedback node.
+   */
+  setFeedbackGain(value) {
+    this.feedbackGainNode_.gain.value = value;
+  }
+
+  /**
    * Create a new voice and add it to |this.activeVoices_|.
    * @param {String} noteName The note to be played, e.g. A4 for an octave 4 A.
    * @param {Number} frequency The corresponding pitch of the note, e.g 440.
    */
   playVoice(noteName, frequency) {
     let voice = new PolySynthVoice(this.context_, noteName, frequency, this);
-    voice.output.connect(this.output);
+    voice.output.connect(this.voiceOutput_);
     this.activeVoices_[noteName] = voice;
     voice.start();
   }

--- a/poly-synth/src/poly-synth.js
+++ b/poly-synth/src/poly-synth.js
@@ -67,26 +67,26 @@ class PolySynth {
 
     // By default no delay is applied. The gain and delay time are
     // experimentally determined.
-    this.delayWetness = 0;
-    this.feedbackDelayGain = 0.5;
-    this.feedbackDelayTime = 0.2;
+    this.delayWetness = 0.6;
+    this.feedbackDelayGain = 0.2;
+    this.feedbackDelayTime = 0.4;
 
     // By default, no reverb is applied.
-    this.reverbWetness = 0;
+    this.reverbWetness = 0.4;
 
     // The initial values for the parameters are experimentally determined.
     this.parameters_ = {
-      gainAttack: 0.1,
-      gainDecay: this.minDecay,
-      gainSustain: 0.5,
-      gainRelease: 0.1,
-      filterCutoff: 440,
-      filterQ: 0,
-      filterAttack: 1,
-      filterDecay: 1,
+      gainAttack: 0.0,
+      gainDecay: 0.32,
+      gainSustain: this.minSustain,
+      gainRelease: 0.13,
+      filterCutoff: 60,
+      filterQ: 15.35,
+      filterAttack: 0,
+      filterDecay: 0.58,
       filterSustain: this.minSustain,
-      filterRelease: this.minRelease,
-      filterDetuneAmount: 1,
+      filterRelease: 0.48,
+      filterDetuneAmount: 3.27,
     };
 
     // Each voice is connected to |this.voiceOutput_|.


### PR DESCRIPTION
In this PR, three master effects have been added to the poly-synth: convolution, feedback delay, and bitcrushing. The PR modifies 4 files:
- poly-synth/index.html: added one dependency, and changed the GUI
- poly-synth/src/poly-synth-demo.js: added GUI components for master effects and impulse response loading.
- poly-synth/src/poly-synth.js: added the audio graph supporting effects and controls for changing effects settings.
- poly-synth/src/poly-synth-voice.js: removed an extraneous blank line!

The demo can be found [here](http://rawgit.com/GoogleChrome/web-audio-samples/8a4615e3124b83c4f783f4c188a8d302ab1f943b/poly-synth/index.html). As I evaluate the demo online, I notice that it takes a couple seconds to load. This is because it takes time to load the impulse response buffers. I may want to consider the number of impulse response buffers so that it loads quicker. 